### PR TITLE
Convert the access token to 1 hour equivalent

### DIFF
--- a/app/configs/OpenBarbellConfig.json
+++ b/app/configs/OpenBarbellConfig.json
@@ -6,5 +6,5 @@
     "webGoogleClientID" : "971870516004-oge4ph6j8s0a4e5lbimr7dc6e22od5jc.apps.googleusercontent.com",
     "endWorkoutTimer" : 3600000,
     "obtainTokenTimer": 1800000,
-    "apiWaitTimer": 1209600000
+    "apiWaitTimer": 3600000
 }


### PR DESCRIPTION
This value is essentially the staging access token timeout. If this works, can update production to this value eventually.

Note that production has a separate config file.